### PR TITLE
Use `undefined`, not `null`, for default options

### DIFF
--- a/src/syncState.js
+++ b/src/syncState.js
@@ -11,7 +11,7 @@ const defaultConfig = {
     predicate: null,
     blacklist: [],
     whitelist: [],
-    broadcastChannelOption: null,
+    broadcastChannelOption: undefined,
     prepareState: state => state,
 };
 


### PR DESCRIPTION
As described in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46480 , the `BroadcastChannel` package will correctly default the options you pass to it if `undefined` is passed as the options object. However, using `null` results in a `TypeError`:

```
TypeError: Cannot read property 'webWorkerSupport' of null
          at fillOptionsWithDefaults (/Users/.../node_modules/redux-state-sync/node_modules/broadcast-channel/dist/lib/options.js:12:22)
          at new BroadcastChannel (/Users/.../node_modules/redux-state-sync/node_modules/broadcast-channel/dist/lib/broadcast-channel.js:23:55)
          at Object.createStateSyncMiddleware (/Users/.../node_modules/redux-state-sync/dist/syncState.js:131:19)
          at Object.<anonymous> (/Users/.../src/redux/store.ts:37:31)
```